### PR TITLE
Support "application/proto" as the Content-Type

### DIFF
--- a/example/example_test.go
+++ b/example/example_test.go
@@ -78,6 +78,27 @@ Content-Type: application/x.prottp
 	},
 
 	{
+        Name:   "test request proto, response proto normal",
+        URL:    "/example.SearchService/Search",
+        Accept: "application/proto",
+        PBReqBody: &example.SearchRequest{
+            Query:         "query string protobuf",
+            PageNumber:    2,
+            ResultPerPage: 10,
+        },
+        ExpectedPBResBody: &example.SearchResponse{
+            Result: []*example.Result{
+                {Url: "query string protobuf", SomeSnakedName: 2},
+            },
+        },
+        ExpectedHeadersDump: `HTTP/1.1 200 OK
+Content-Length: 27
+Content-Type: application/proto
+
+`,
+    },
+
+	{
 		Name:   "test request json, response x.prottp normal",
 		URL:    "/example.SearchService/Search",
 		Accept: "application/x.prottp, application/json;q=0.9, */*;q=0.8",
@@ -97,6 +118,27 @@ Content-Type: application/x.prottp
 
 `,
 	},
+
+    {
+        Name:   "test request json, response proto normal",
+        URL:    "/example.SearchService/Search",
+        Accept: "application/proto, application/json;q=0.9, */*;q=0.8",
+        JSONReqBody: `{
+            "query": "query string protobuf",
+            "page_number": 1,
+            "result_per_page": 10
+        }`,
+        ExpectedPBResBody: &example.SearchResponse{
+            Result: []*example.Result{
+                {Url: "query string protobuf", SomeSnakedName: 2},
+            },
+        },
+        ExpectedHeadersDump: `HTTP/1.1 200 OK
+Content-Length: 27
+Content-Type: application/proto
+
+`,
+    },
 
 	{
 		Name:   "test request x.prottp, response json normal",

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -78,25 +78,25 @@ Content-Type: application/x.prottp
 	},
 
 	{
-        Name:   "test request proto, response proto normal",
-        URL:    "/example.SearchService/Search",
-        Accept: "application/proto",
-        PBReqBody: &example.SearchRequest{
-            Query:         "query string protobuf",
-            PageNumber:    2,
-            ResultPerPage: 10,
-        },
-        ExpectedPBResBody: &example.SearchResponse{
-            Result: []*example.Result{
-                {Url: "query string protobuf", SomeSnakedName: 2},
-            },
-        },
-        ExpectedHeadersDump: `HTTP/1.1 200 OK
+		Name:   "test request proto, response proto normal",
+		URL:    "/example.SearchService/Search",
+		Accept: "application/proto",
+		PBReqBody: &example.SearchRequest{
+			Query:         "query string protobuf",
+			PageNumber:    2,
+			ResultPerPage: 10,
+		},
+		ExpectedPBResBody: &example.SearchResponse{
+			Result: []*example.Result{
+				{Url: "query string protobuf", SomeSnakedName: 2},
+			},
+		},
+		ExpectedHeadersDump: `HTTP/1.1 200 OK
 Content-Length: 27
 Content-Type: application/proto
 
 `,
-    },
+	},
 
 	{
 		Name:   "test request json, response x.prottp normal",
@@ -119,26 +119,26 @@ Content-Type: application/x.prottp
 `,
 	},
 
-    {
-        Name:   "test request json, response proto normal",
-        URL:    "/example.SearchService/Search",
-        Accept: "application/proto, application/json;q=0.9, */*;q=0.8",
-        JSONReqBody: `{
+	{
+		Name:   "test request json, response proto normal",
+		URL:    "/example.SearchService/Search",
+		Accept: "application/proto, application/json;q=0.9, */*;q=0.8",
+		JSONReqBody: `{
             "query": "query string protobuf",
             "page_number": 1,
             "result_per_page": 10
         }`,
-        ExpectedPBResBody: &example.SearchResponse{
-            Result: []*example.Result{
-                {Url: "query string protobuf", SomeSnakedName: 2},
-            },
-        },
-        ExpectedHeadersDump: `HTTP/1.1 200 OK
+		ExpectedPBResBody: &example.SearchResponse{
+			Result: []*example.Result{
+				{Url: "query string protobuf", SomeSnakedName: 2},
+			},
+		},
+		ExpectedHeadersDump: `HTTP/1.1 200 OK
 Content-Length: 27
 Content-Type: application/proto
 
 `,
-    },
+	},
 
 	{
 		Name:   "test request x.prottp, response json normal",

--- a/prottp.go
+++ b/prottp.go
@@ -117,7 +117,7 @@ func shouldReturnJSON(r *http.Request) bool {
 	if len(acceptString) == 0 {
 		return isContentTypeJSON(r)
 	}
-	
+
 	jsonIndex := strings.Index(acceptString, jsonContentType)
 	xprottpIndex := strings.Index(acceptString, xprottpContentType)
 	protoIndex := strings.Index(acceptString, protoContentType)

--- a/prottp.go
+++ b/prottp.go
@@ -102,6 +102,7 @@ var unmarshaler = jsonpb.Unmarshaler{
 
 const jsonContentType = "application/json"
 const xprottpContentType = "application/x.prottp"
+const protoContentType = "application/proto"
 
 func isMimeTypeJSON(contentType string) bool {
 	return strings.Index(strings.ToLower(contentType), jsonContentType) >= 0
@@ -116,10 +117,12 @@ func shouldReturnJSON(r *http.Request) bool {
 	if len(acceptString) == 0 {
 		return isContentTypeJSON(r)
 	}
+	
 	jsonIndex := strings.Index(acceptString, jsonContentType)
 	xprottpIndex := strings.Index(acceptString, xprottpContentType)
+	protoIndex := strings.Index(acceptString, protoContentType)
 
-	if jsonIndex < 0 && xprottpIndex < 0 {
+	if jsonIndex < 0 && xprottpIndex < 0 && protoIndex < 0 {
 		return isContentTypeJSON(r)
 	}
 
@@ -129,12 +132,11 @@ func shouldReturnJSON(r *http.Request) bool {
 	if xprottpIndex < 0 {
 		xprottpIndex = 10000
 	}
-
-	if jsonIndex < xprottpIndex {
-		return true
+	if protoIndex < 0 {
+		protoIndex = 10001
 	}
 
-	return false
+	return jsonIndex < xprottpIndex && jsonIndex < protoIndex
 }
 
 func wrapMethod(service interface{}, m grpc.MethodDesc, interceptor grpc.UnaryServerInterceptor) http.Handler {
@@ -200,6 +202,8 @@ func WriteMessage(statusCode int, msg proto.Message, w http.ResponseWriter, r *h
 		contentType := xprottpContentType
 		if isJSON {
 			contentType = jsonContentType
+		} else if strings.Index(strings.ToLower(r.Header.Get("Accept")), protoContentType) >= 0 {
+			contentType = protoContentType
 		}
 		w.Header().Set("Content-Type", contentType)
 	}


### PR DESCRIPTION
## Type of change

- feature

## Description

Sets the Content-Type to “application/proto” when the Accept header is specified as "application/proto",
to support [connect-es](https://github.com/connectrpc/connect-es), an alternative to [ecjs/prottp](https://github.com/theplant/ecjs/tree/master/packages/ecjs/prottp).
Demo: https://github.com/theplant/ecjs/pull/3941#discussion_r1770943698

## Related issues

N/A

## Notes for reviewer

N/A
