### PR TITLE
chore: replace the deprecated `io/ioutil.ReadAll` with `io.ReadAll`

### DIFF
--- a/prottp.go
+++ b/prottp.go
@@ -3,7 +3,7 @@ package prottp
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -154,7 +154,7 @@ func wrapMethod(service interface{}, m grpc.MethodDesc, interceptor grpc.UnarySe
 			}
 
 			var buff []byte
-			buff, err = ioutil.ReadAll(r.Body)
+			buff, err = io.ReadAll(r.Body)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
Please read through this and fill out the checks. If they're not relevant, put N/A there.
-->

## Type of change

- cleanup


<!--
Add one or more of the following kinds:
- bug
- feature
- documentation
- configuration
- deployment (for another change)
-->

## Description

This fixes:

```
"io/ioutil" is deprecated: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details.
```

<!--
What's the change? Why do we need it?
-->

## Related issues

n/a

<!--
Which Jira issue are you resolving? Put all references here.
-->

## Notes for reviewer

n/a

<!--
What else does a reviewer need to know?
-->
